### PR TITLE
Sorting out loads of warnings

### DIFF
--- a/gdb-7.5.1/gdb/amigaos-nat.c
+++ b/gdb-7.5.1/gdb/amigaos-nat.c
@@ -1287,8 +1287,9 @@ amigaos_create_inferior (struct target_ops *ops, char *exec_file, char *args, ch
 		{
 			/* TODO: does this ptid need to be set? */
 			ptid_t dummy_ptid;
+
 			amigaos_stop(dummy_ptid);
-			amigaos_kill_inferior(dummy_ptid);
+			amigaos_kill_inferior(NULL);
 		}
 		else
 			error ("Program not killed\n");


### PR DESCRIPTION
Fixed lots of signatures for the set up of amigaos_ops in init_amigaos_ops (). Replaced deprecated CreatePort (), DeletePort () and AllocVec () calls. Added getting of current regcache.